### PR TITLE
Improve the flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake


### PR DESCRIPTION
Development tools like cargo... should be provided by a nix devshell.
Using direnv and the new `.envrc` file one can automatically enter the devshell.