### PR TITLE
Earlier cli parsing and refactors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/docs
 target/
+.direnv/

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,6 @@
 //! Main logic for the application, handling of events and mutation of the state
 
+use crate::config::Config;
 use crate::selection::Speed;
 use std::borrow::Cow;
 use std::time::Instant;
@@ -8,6 +9,7 @@ use crate::message::Message;
 use crate::screenshot::RgbaHandle;
 use crate::selection::selection_lock::OptionalSelectionExt;
 use crate::theme::THEME;
+use clap::Parser;
 use iced::alignment::Vertical;
 use iced::mouse::Cursor;
 use iced::widget::canvas::Path;
@@ -87,6 +89,8 @@ pub struct App {
     pub screenshot: RgbaHandle,
     /// Area of the screen that is selected for capture
     pub selection: Option<Selection>,
+    /// The user specified configuration
+    pub config: Config,
     /// Errors to display to the user
     pub errors: Vec<ErrorMessage>,
 }
@@ -101,6 +105,7 @@ impl Default for App {
             selection: None,
             selections_created: 0,
             errors: vec![],
+            config: Config::parse()
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -105,7 +105,7 @@ impl Default for App {
             selection: None,
             selections_created: 0,
             errors: vec![],
-            config: Config::parse()
+            config: Config::parse(),
         }
     }
 }

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,20 +1,19 @@
 //! The canvas handles drawing the selection frame
-use iced::advanced::debug::core::SmolStr;
-use iced::keyboard::key::Named::F11;
-use iced::keyboard::key::Named::{Enter, Escape, Shift};
+use iced::Event::{Keyboard, Mouse};
 use iced::keyboard::Event::KeyPressed;
 use iced::keyboard::Event::KeyReleased;
 use iced::keyboard::Key::{Character, Named};
 use iced::keyboard::Modifiers as Mods;
+use iced::keyboard::key::Named::F11;
+use iced::keyboard::key::Named::{Enter, Escape, Shift};
 use iced::mouse::Button::{Left, Middle, Right};
 use iced::mouse::Event::ButtonPressed;
 use iced::mouse::Event::ButtonReleased;
 use iced::mouse::Event::CursorMoved;
-use iced::Event::{Keyboard, Mouse};
 use iced::{
-    mouse::{self, Interaction},
-    widget::{self, canvas, Action},
     Rectangle, Renderer, Theme,
+    mouse::{self, Interaction},
+    widget::{self, Action, canvas},
 };
 
 /// Holds information about the mouse
@@ -30,11 +29,11 @@ pub struct MouseState {
 
 use crate::selection::Speed;
 use crate::{
+    App,
     corners::SideOrCorner,
     message::Message,
-    selection::{selection_lock::OptionalSelectionExt as _, Selection, SelectionStatus},
+    selection::{Selection, SelectionStatus, selection_lock::OptionalSelectionExt as _},
     theme::THEME,
-    App,
 };
 
 impl canvas::Program<Message> for App {
@@ -167,7 +166,8 @@ impl canvas::Program<Message> for App {
             }) if *c == "s" => Message::SaveScreenshot,
             Keyboard(KeyPressed {
                 key: Named(F11), ..
-            }) => Message::SelectFullScreen,
+            })
+            | Mouse(ButtonPressed(Middle)) => Message::SelectFullScreen,
             Keyboard(KeyPressed {
                 key: Named(Shift), ..
             }) => {
@@ -269,7 +269,6 @@ impl canvas::Program<Message> for App {
             Mouse(CursorMoved { position }) if self.selection.is_some_and(Selection::is_create) => {
                 Message::ExtendNewSelection(*position)
             }
-            Mouse(ButtonPressed(Middle)) => Message::SelectFullScreen,
             _ => return None,
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,5 @@
 //! Command line arguments to configure the program
-use std::sync::LazyLock;
-
 use clap::Parser;
-
-/// Configuration of the app
-pub static CONFIG: LazyLock<Config> = LazyLock::new(Config::parse);
 
 /// Configuration for the program
 #[derive(Parser, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,4 +36,3 @@ pub use clipboard::{CLIPBOARD_DAEMON_ID, run_clipboard_daemon};
 
 pub use app::App;
 pub use app::SAVED_IMAGE;
-pub use config::CONFIG;


### PR DESCRIPTION
Previously the cli arguments in form of the `Config` struct was only parsed once the left mouse button is released. This is problematic for arguments like `--version` or `--help`, ferrishot would start but abort when the mouse button is released to show the version.

Now the Config is part of `App` and the cli arguments are parsed when iced inits `App`.

Also I did some refactors to have less/smaller if clauses in a match expression, no problem if you don't like those just let me know :)