### PR TITLE
added aur installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ inputs.ferrishot.url = "github:nik-rev/ferrishot/main";
 inputs.ferrishot.packages.${pkgs.system}.default
 ```
 
+### Arch AUR
+
+```sh
+yay -S ferrishot-bin
+```
+
 ### Cargo
 
 If you use Linux, see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for details on which dependencies you will need.


### PR DESCRIPTION
I've created a binary aur package for arch linux: https://aur.archlinux.org/packages/ferrishot-bin

Let me know if you do not want it on the aur.